### PR TITLE
Fix and enable the dependency deobfuscation artifact transformer

### DIFF
--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
   id("maven-publish")
   id("org.jetbrains.gradle.plugin.idea-ext") version "1.1.7"
   id("eclipse")
-  id("com.gtnewhorizons.retrofuturagradle") version "1.2.3"
+  id("com.gtnewhorizons.retrofuturagradle") version "1.2.5"
 }
 
 // Project properties
@@ -99,6 +99,10 @@ repositories {
 dependencies {
   // Adds NotEnoughItems and its dependencies (CCL&CCC) to runClient/runServer
   runtimeOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.3.39-GTNH:dev")
+  // Example: grab the ic2 jar from curse maven and deobfuscate
+  // api(rfg.deobf("curse.maven:ic2-242638:2353971"))
+  // Example: grab the ic2 jar from libs/ in the workspace and deobfuscate
+  // api(rfg.deobf(project.files("libs/ic2.jar")))
 }
 
 // Publishing to a Maven repository

--- a/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/modutils/ModUtils.java
+++ b/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/modutils/ModUtils.java
@@ -1,19 +1,29 @@
 package com.gtnewhorizons.retrofuturagradle.modutils;
 
+import java.io.File;
+import java.net.URI;
+import java.net.URL;
+import java.nio.file.Path;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.ConfigurationContainer;
-import org.gradle.api.artifacts.Dependency;
-import org.gradle.api.artifacts.ModuleDependency;
-import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.attributes.Attribute;
-import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.file.FileTree;
+import org.gradle.api.file.RegularFile;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.SetProperty;
 
 import com.gtnewhorizons.retrofuturagradle.MinecraftExtension;
 import com.gtnewhorizons.retrofuturagradle.ObfuscationAttribute;
+import com.gtnewhorizons.retrofuturagradle.mcp.GenSrgMappingsTask;
 import com.gtnewhorizons.retrofuturagradle.mcp.MCPTasks;
 import com.gtnewhorizons.retrofuturagradle.minecraft.MinecraftTasks;
+import com.gtnewhorizons.retrofuturagradle.util.Utilities;
 
 /**
  * Gradle utilities for developing mods
@@ -27,6 +37,14 @@ public class ModUtils {
     private final MinecraftExtension mcExt;
     private final MinecraftTasks minecraftTasks;
     private final MCPTasks mcpTasks;
+    private final ConfigurableFileCollection depFilesToDeobf;
+    private final SetProperty<String> depModulesToDeobf;
+
+    /**
+     * Attribute that controls running the deobfuscation artifact transform.
+     */
+    public static final Attribute<Boolean> DEOBFUSCATOR_TRANSFORMED = Attribute
+            .of("rfgDeobfuscatorTransformed", Boolean.class);
 
     public ModUtils(Project project, MinecraftExtension mcExt, MinecraftTasks minecraftTasks, MCPTasks mcpTasks) {
         this.project = project;
@@ -38,52 +56,82 @@ public class ModUtils {
         final ObjectFactory objects = project.getObjects();
         final ConfigurationContainer configs = project.getConfigurations();
 
+        this.depFilesToDeobf = objects.fileCollection();
+        this.depModulesToDeobf = objects.setProperty(String.class);
+
         project.getTasks().register("applyDecompilerCleanupToMain", ApplyDecompCleanupTask.class, task -> {
             task.setGroup(TASK_GROUP_USER);
             task.setDescription(
                     "Apply MCP decompiler cleanup to the main source set, doing things like replacing numerical OpenGL constants with their names");
         });
 
-        // Dependency deobfuscation utilities
-        /*
-         * see comment on deobfuscate deps.registerTransform(DependencyDeobfuscationTransform.class, spec -> {
-         * spec.getFrom().attribute(ObfuscationAttribute.OBFUSCATION_ATTRIBUTE, ObfuscationAttribute.getSrg(objects));
-         * spec.getTo().attribute(ObfuscationAttribute.OBFUSCATION_ATTRIBUTE, ObfuscationAttribute.getMcp(objects));
-         * final DependencyDeobfuscationTransform.Parameters params = spec.getParameters(); params.getSrgFile()
-         * .set(mcpTasks.getTaskGenerateForgeSrgMappings().flatMap(GenSrgMappingsTask::getSrgToMcp));
-         * params.getFieldsCsv()
-         * .set(mcpTasks.getTaskGenerateForgeSrgMappings().flatMap(GenSrgMappingsTask::getFieldsCsv));
-         * params.getMethodsCsv()
-         * .set(mcpTasks.getTaskGenerateForgeSrgMappings().flatMap(GenSrgMappingsTask::getMethodsCsv));
-         * params.getMinecraftJar()
-         * .set(mcpTasks.getTaskDeobfuscateMergedJarToSrg().flatMap(DeobfuscateTask::getOutputJar)); });
-         */
-    }
+        // Dependency deobfuscation utilities, see comment on deobfuscate
+        deps.registerTransform(DependencyDeobfuscationTransform.class, spec -> {
+            spec.getFrom().attribute(DEOBFUSCATOR_TRANSFORMED, Boolean.FALSE);
+            spec.getTo().attribute(DEOBFUSCATOR_TRANSFORMED, Boolean.TRUE);
+            final DependencyDeobfuscationTransform.Parameters params = spec.getParameters();
+            params.getFieldsCsv()
+                    .set(mcpTasks.getTaskGenerateForgeSrgMappings().flatMap(GenSrgMappingsTask::getFieldsCsv));
+            params.getMethodsCsv()
+                    .set(mcpTasks.getTaskGenerateForgeSrgMappings().flatMap(GenSrgMappingsTask::getMethodsCsv));
+            params.getFilesToDeobf().from(depFilesToDeobf);
+            params.getModulesToDeobf().set(depModulesToDeobf);
+        });
 
-    // TODO: Make public once Gradle fixes artifact transforms
-    private Dependency deobfuscate(Object depSpec) {
-        final DependencyHandler deps = project.getDependencies();
-        final Dependency rawDep = deps.create(depSpec);
-        if (!(rawDep instanceof ModuleDependency)) {
-            throw new IllegalArgumentException(
-                    "deobfuscate() needs a ModuleDependency, was given " + rawDep.getClass());
-        }
-        ModuleDependency dep = (ModuleDependency) rawDep;
-        final ModuleIdentifier moduleSpec = DefaultModuleIdentifier.newId(dep.getGroup(), dep.getName());
-        deps.getComponents().withModule(moduleSpec, ctx -> {
-            ctx.allVariants(variant -> {
-                variant.getAttributes().attribute(
-                        ObfuscationAttribute.OBFUSCATION_ATTRIBUTE,
-                        ObfuscationAttribute.getSrg(project.getObjects()));
-                for (Attribute attrib : variant.getAttributes().keySet()) {
-                    project.getLogger().warn(
-                            String.format(
-                                    " - %s : %s",
-                                    attrib.toString(),
-                                    variant.getAttributes().getAttribute(attrib).toString()));
+        project.afterEvaluate(_p -> {
+            project.getDependencies().getArtifactTypes().getByName("jar").getAttributes()
+                    .attribute(DEOBFUSCATOR_TRANSFORMED, Boolean.FALSE);
+            project.getConfigurations().configureEach(cfg -> {
+                ObfuscationAttribute requiredObfuscation = cfg.getAttributes()
+                        .getAttribute(ObfuscationAttribute.OBFUSCATION_ATTRIBUTE);
+                if (requiredObfuscation.getName().equals(ObfuscationAttribute.MCP)) {
+                    cfg.getAttributes().attribute(DEOBFUSCATOR_TRANSFORMED, Boolean.TRUE);
                 }
             });
         });
-        return rawDep;
+
+        deps.getExtensions().add("rfg", new RfgDependencyExtension());
+    }
+
+    /**
+     * Wrap a dependency specification with a call to this function to make RFG deobfuscate it on resolution in
+     * MCP-mapped configurations.
+     */
+    public Object deobfuscate(Object depSpec) {
+        if (depSpec instanceof CharSequence) {
+            depModulesToDeobf.add(depSpec.toString());
+        } else if (depSpec instanceof Map<?, ?>depMap) {
+            final String group = Utilities.getMapStringOrBlank(depMap, "group");
+            final String module = Utilities.getMapStringOrBlank(depMap, "name");
+            final String version = Utilities.getMapStringOrBlank(depMap, "version");
+            final String classifier = Utilities.getMapStringOrBlank(depMap, "classifier");
+            String gmv = group + ":" + module + ":" + version;
+            if (StringUtils.isNotBlank(classifier)) {
+                gmv += ":" + classifier;
+            }
+            depModulesToDeobf.add(gmv);
+        } else if (depSpec instanceof File || depSpec instanceof RegularFile
+                || depSpec instanceof Path
+                || depSpec instanceof URI
+                || depSpec instanceof URL
+                || depSpec instanceof FileTree
+                || depSpec instanceof FileCollection) {
+                    depFilesToDeobf.from(depSpec);
+                } else {
+                    throw new UnsupportedOperationException(
+                            "Unsupported dependency type " + depSpec.getClass() + " for RFG deobfuscation");
+                }
+        return depSpec;
+    }
+
+    public class RfgDependencyExtension {
+
+        /**
+         * Wrap a dependency specification with a call to this function to make RFG deobfuscate it on resolution in
+         * MCP-mapped configurations.
+         */
+        public Object deobf(Object depSpec) {
+            return ModUtils.this.deobfuscate(depSpec);
+        }
     }
 }

--- a/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/util/SimpleSrgRemapper.java
+++ b/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/util/SimpleSrgRemapper.java
@@ -1,0 +1,46 @@
+package com.gtnewhorizons.retrofuturagradle.util;
+
+import java.util.Map;
+
+import org.objectweb.asm.commons.Remapper;
+
+/**
+ * A {@link Remapper} using a {@link Map} to define its mapping, using simple SRG-style mappings.
+ */
+public class SimpleSrgRemapper extends Remapper {
+
+    private final Map<String, String> mapping;
+
+    public SimpleSrgRemapper(final Map<String, String> mapping) {
+        this.mapping = mapping;
+    }
+
+    @Override
+    public String mapMethodName(final String owner, final String name, final String descriptor) {
+        String remappedName = map(name);
+        return remappedName == null ? name : remappedName;
+    }
+
+    @Override
+    public String mapInvokeDynamicMethodName(final String name, final String descriptor) {
+        String remappedName = map(name);
+        return remappedName == null ? name : remappedName;
+    }
+
+    @Override
+    public String mapAnnotationAttributeName(final String descriptor, final String name) {
+        String remappedName = map(name);
+        return remappedName == null ? name : remappedName;
+    }
+
+    @Override
+    public String mapFieldName(final String owner, final String name, final String descriptor) {
+        String remappedName = map(name);
+        return remappedName == null ? name : remappedName;
+    }
+
+    @Override
+    public String map(final String key) {
+        return mapping.get(key);
+    }
+}


### PR DESCRIPTION
Adds a `rfg.deobf(..)` dependency transformer that deobfuscates the jars as appropriate.

Closes #13 