### PR TITLE
Basic mapping migration

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -324,6 +324,8 @@ val combinedShadowJar = tasks.register<Jar>("combinedShadowJar") {
   exclude("META-INF/NOTICE")
   exclude("META-INF/NOTICE*")
   exclude("META-INF/INDEX.LIST", "META-INF/*.SF", "META-INF/*.DSA", "META-INF/*.RSA", "module-info.class") // shadowJar defaults
+  exclude("LICENSE*")
+  exclude(".*", "*.html", "*.profile", "*.jar", "*.properties", "*.xml", "*.list", "META-INF/eclipse.inf") // eclipse stuff
 }
 
 tasks.jar.configure {

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -263,6 +263,7 @@ val depsShadowJar = tasks.register<ShadowJar>("depsShadowJar") {
     // we're already shading this in combinedShadowJar
     exclude(project(":oldasmwrapper"))
   }
+  mergeServiceFiles()
 }
 
 val mainShadowJar = tasks.register<ShadowJar>("mainShadowJar") {

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -134,6 +134,7 @@ dependencies {
   // We use Paper's Mercury fork because it both supports Java 17 and is binary compatible with mercurymixin.
   implementation("org.cadixdev:mercury:0.1.2-paperweight-SNAPSHOT")
   implementation("org.cadixdev:mercurymixin:0.1.0-SNAPSHOT")
+  implementation("net.fabricmc:mapping-io:0.5.1")
   // Use JUnit Jupiter for testing.
   testImplementation("org.junit.jupiter:junit-jupiter:5.9.2")
   testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -49,6 +49,20 @@ repositories {
     name = "gtnh"
     url = uri("https://nexus.gtnewhorizons.com/repository/public/")
   }
+  maven {
+    name = "paper"
+    url = uri("https://papermc.io/repo/repository/maven-snapshots/")
+    mavenContent {
+      includeGroup("org.cadixdev")
+    }
+  }
+  maven {
+    name = "sonatype"
+    url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+    mavenContent {
+      includeGroup("org.cadixdev")
+    }
+  }
   mavenCentral {}
   gradlePluginPortal()
 }
@@ -116,6 +130,10 @@ dependencies {
   implementation("com.google.code.gson:gson:2.10.1")
   // Forge utilities (to be merged into the source tree in the future)
 
+  // Source remapping
+  // We use Paper's Mercury fork because it both supports Java 17 and is binary compatible with mercurymixin.
+  implementation("org.cadixdev:mercury:0.1.2-paperweight-SNAPSHOT")
+  implementation("org.cadixdev:mercurymixin:0.1.0-SNAPSHOT")
   // Use JUnit Jupiter for testing.
   testImplementation("org.junit.jupiter:junit-jupiter:5.9.2")
   testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/modutils/MigrateMappingsTask.java
+++ b/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/modutils/MigrateMappingsTask.java
@@ -2,6 +2,7 @@ package com.gtnewhorizons.retrofuturagradle.modutils;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -110,8 +111,9 @@ public abstract class MigrateMappingsTask extends DefaultTask {
 
         final Mercury mercury = new Mercury();
 
-        mercury.getClassPath()
-                .addAll(getCompileClasspath().getFiles().stream().map(File::toPath).collect(Collectors.toList()));
+        mercury.getClassPath().addAll(
+                getCompileClasspath().getFiles().stream().map(File::toPath).filter(Files::exists)
+                        .collect(Collectors.toList()));
 
         // Fixes some issues like broken javadoc in Forge, and JDT not understanding Hodgepodge's obfuscated voxelmap
         // targets.

--- a/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/modutils/MigrateMappingsTask.java
+++ b/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/modutils/MigrateMappingsTask.java
@@ -1,16 +1,23 @@
 package com.gtnewhorizons.retrofuturagradle.modutils;
 
 import com.gtnewhorizons.retrofuturagradle.mcp.GenSrgMappingsTask;
+import com.gtnewhorizons.retrofuturagradle.mcp.InjectTagsTask;
+import com.gtnewhorizons.retrofuturagradle.mcp.SharedMCPTasks;
 import com.gtnewhorizons.retrofuturagradle.util.Utilities;
 import com.opencsv.CSVReader;
+import org.apache.commons.io.FileUtils;
 import org.cadixdev.lorenz.MappingSet;
 import org.cadixdev.lorenz.io.MappingFormats;
 import org.cadixdev.lorenz.io.MappingsWriter;
 import org.cadixdev.lorenz.model.FieldMapping;
 import org.cadixdev.lorenz.model.MethodMapping;
 import org.cadixdev.lorenz.model.TopLevelClassMapping;
+import org.cadixdev.mercury.Mercury;
+import org.cadixdev.mercury.mixin.MixinRemapper;
+import org.cadixdev.mercury.remapper.MercuryRemapper;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.jvm.tasks.Jar;
 import org.gradle.api.tasks.options.Option;
 
 import java.io.File;
@@ -22,23 +29,41 @@ public class MigrateMappingsTask extends DefaultTask {
 
     private static final boolean DEBUG_WRITE_DIFF = Boolean.parseBoolean(System.getenv("RFG_DEBUG_WRITE_MAPPING_DIFF"));
 
-    private String mcpDir;
+    private File mcpDir;
+    private File inputDir;
+    private File outputDir;
 
-    @Option(option = "mcpDir", description = "A directory containing the mappings to migrate to, using MCP's fields.csv and methods.csv format.")
+    @Option(option = "mcpDir", description = "The directory containing the mappings to migrate to, using MCP's fields.csv and methods.csv format.")
     public void setMcpDir(String mcpDir) {
-        this.mcpDir = mcpDir;
+        this.mcpDir = new File(mcpDir);
+    }
+
+    @Option(option = "inputDir", description = "The directory containing the source code to migrate.")
+    public void setInputDir(String inputDir) {
+        this.inputDir = new File(inputDir);
+    }
+
+    @Option(option = "outputDir", description = "The directory the migrated source code should be written to.")
+    public void setOutputDir(String outputDir) {
+        this.outputDir = new File(outputDir);
     }
     
     @TaskAction
-    public void migrateMappings() throws IOException {
+    public void migrateMappings() throws Exception {
         if(mcpDir == null) {
             throw new IllegalArgumentException("--mcpDir must be provided.");
+        }
+        if(inputDir == null) {
+            inputDir = new File(getProject().getProjectDir(), "src/main/java");
+        }
+        if(outputDir == null) {
+            outputDir = new File(getProject().getProjectDir(), "src/main/java");
         }
         GenSrgMappingsTask genSrgMappings = (GenSrgMappingsTask)getProject().getTasks().getByName("generateForgeSrgMappings");
         File currentFields = genSrgMappings.getFieldsCsv().getAsFile().get();
         File currentMethods = genSrgMappings.getMethodsCsv().getAsFile().get();
 
-        File target = new File(mcpDir);
+        File target = mcpDir;
         File srg = genSrgMappings.getInputSrg().getAsFile().get();
 
         MappingSet notchSrg = MappingFormats.SRG.read(srg.toPath());
@@ -51,6 +76,25 @@ public class MigrateMappingsTask extends DefaultTask {
                 w.write(diffMcp);
             }
         }
+
+        final Mercury mercury = new Mercury();
+
+        // There's probably a better way to do this
+        mercury.getClassPath().add(((Jar)getProject().getTasks().getByName("packagePatchedMc")).getArchiveFile().get().getAsFile().toPath());
+        mercury.getClassPath().add(((InjectTagsTask)getProject().getTasks().getByName("injectTags")).getOutputDir().getAsFile().get().toPath());
+        for (File file : getProject().getConfigurations().getByName("compileClasspath").getFiles()) {
+            mercury.getClassPath().add(file.toPath());
+        }
+        // Fixes some issues like broken javadoc in Forge, and JDT not understanding Hodgepodge's obfuscated voxelmap targets.
+        mercury.setGracefulClasspathChecks(true);
+
+        mercury.getProcessors().add(MixinRemapper.create(diffMcp));
+        mercury.getProcessors().add(MercuryRemapper.create(diffMcp));
+
+        // TODO actually get this from the project
+        mercury.setSourceCompatibility("17");
+
+        mercury.rewrite(inputDir.toPath(), outputDir.toPath());
     }
 
     /** Returns the difference between two mappings of the same root.

--- a/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/modutils/MigrateMappingsTask.java
+++ b/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/modutils/MigrateMappingsTask.java
@@ -20,6 +20,8 @@ import java.util.Map;
 
 public class MigrateMappingsTask extends DefaultTask {
 
+    private static final boolean DEBUG_WRITE_DIFF = Boolean.parseBoolean(System.getenv("RFG_DEBUG_WRITE_MAPPING_DIFF"));
+
     private String mcpDir;
 
     @Option(option = "mcpDir", description = "A directory containing the mappings to migrate to, using MCP's fields.csv and methods.csv format.")
@@ -43,9 +45,11 @@ public class MigrateMappingsTask extends DefaultTask {
         MappingSet currentSrgMcp = createSrgMcpMappingSet(notchSrg, readCsv(currentFields), readCsv(currentMethods));
         MappingSet targetSrgMcp = createSrgMcpMappingSet(notchSrg, readCsv(new File(target, "fields.csv")), readCsv(new File(target, "methods.csv")));
         MappingSet diffMcp = diff(currentSrgMcp, targetSrgMcp);
-        
-        try(MappingsWriter w = MappingFormats.SRG.createWriter(new File("diff.srg").toPath())) {
-            w.write(diffMcp);
+
+        if(DEBUG_WRITE_DIFF) {
+            try (MappingsWriter w = MappingFormats.SRG.createWriter(new File(getProject().getRootDir(), "diff.srg").toPath())) {
+                w.write(diffMcp);
+            }
         }
     }
 

--- a/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/modutils/MigrateMappingsTask.java
+++ b/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/modutils/MigrateMappingsTask.java
@@ -63,7 +63,7 @@ public class MigrateMappingsTask extends DefaultTask {
         if(outputDir == null) {
             outputDir = getProject().file("src/main/java");
         }
-        GenSrgMappingsTask genSrgMappings = (GenSrgMappingsTask)getProject().getTasks().getByName("generateForgeSrgMappings");
+        GenSrgMappingsTask genSrgMappings = getProject().getTasks().named("generateForgeSrgMappings", GenSrgMappingsTask.class).get();
         File currentFields = genSrgMappings.getFieldsCsv().getAsFile().get();
         File currentMethods = genSrgMappings.getMethodsCsv().getAsFile().get();
 
@@ -84,8 +84,8 @@ public class MigrateMappingsTask extends DefaultTask {
         final Mercury mercury = new Mercury();
 
         // There's probably a better way to do this
-        mercury.getClassPath().add(((Jar)getProject().getTasks().getByName("packagePatchedMc")).getArchiveFile().get().getAsFile().toPath());
-        mercury.getClassPath().add(((InjectTagsTask)getProject().getTasks().getByName("injectTags")).getOutputDir().getAsFile().get().toPath());
+        mercury.getClassPath().add(getProject().getTasks().named("packagePatchedMc", Jar.class).get().getArchiveFile().get().getAsFile().toPath());
+        mercury.getClassPath().add(getProject().getTasks().named("injectTags", InjectTagsTask.class).get().getOutputDir().getAsFile().get().toPath());
         for (File file : getProject().getConfigurations().getByName("compileClasspath").getFiles()) {
             mercury.getClassPath().add(file.toPath());
         }

--- a/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/modutils/MigrateMappingsTask.java
+++ b/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/modutils/MigrateMappingsTask.java
@@ -39,17 +39,17 @@ public class MigrateMappingsTask extends DefaultTask {
 
     @Option(option = "mcpDir", description = "The directory containing the mappings to migrate to, using MCP's fields.csv and methods.csv format.")
     public void setMcpDir(String mcpDir) {
-        this.mcpDir = new File(getProject().getProjectDir(), mcpDir);
+        this.mcpDir = getProject().file(mcpDir);
     }
 
     @Option(option = "inputDir", description = "The directory containing the source code to migrate.")
     public void setInputDir(String inputDir) {
-        this.inputDir = new File(getProject().getProjectDir(), inputDir);
+        this.inputDir = getProject().file(inputDir);
     }
 
     @Option(option = "outputDir", description = "The directory the migrated source code should be written to.")
     public void setOutputDir(String outputDir) {
-        this.outputDir = new File(getProject().getProjectDir(), outputDir);
+        this.outputDir = getProject().file(outputDir);
     }
     
     @TaskAction
@@ -58,10 +58,10 @@ public class MigrateMappingsTask extends DefaultTask {
             throw new IllegalArgumentException("--mcpDir must be provided.");
         }
         if(inputDir == null) {
-            inputDir = new File(getProject().getProjectDir(), "src/main/java");
+            inputDir = getProject().file("src/main/java");
         }
         if(outputDir == null) {
-            outputDir = new File(getProject().getProjectDir(), "src/main/java");
+            outputDir = getProject().file("src/main/java");
         }
         GenSrgMappingsTask genSrgMappings = (GenSrgMappingsTask)getProject().getTasks().getByName("generateForgeSrgMappings");
         File currentFields = genSrgMappings.getFieldsCsv().getAsFile().get();

--- a/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/modutils/MigrateMappingsTask.java
+++ b/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/modutils/MigrateMappingsTask.java
@@ -1,9 +1,13 @@
 package com.gtnewhorizons.retrofuturagradle.modutils;
 
-import com.gtnewhorizons.retrofuturagradle.mcp.GenSrgMappingsTask;
-import com.gtnewhorizons.retrofuturagradle.mcp.InjectTagsTask;
-import com.gtnewhorizons.retrofuturagradle.util.Utilities;
-import com.opencsv.CSVReader;
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import javax.inject.Inject;
+
 import org.cadixdev.lorenz.MappingSet;
 import org.cadixdev.lorenz.io.MappingFormats;
 import org.cadixdev.lorenz.io.MappingsWriter;
@@ -24,15 +28,13 @@ import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
-import org.gradle.jvm.tasks.Jar;
 import org.gradle.api.tasks.options.Option;
+import org.gradle.jvm.tasks.Jar;
 
-import javax.inject.Inject;
-import java.io.File;
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.function.Consumer;
+import com.gtnewhorizons.retrofuturagradle.mcp.GenSrgMappingsTask;
+import com.gtnewhorizons.retrofuturagradle.mcp.InjectTagsTask;
+import com.gtnewhorizons.retrofuturagradle.util.Utilities;
+import com.opencsv.CSVReader;
 
 public abstract class MigrateMappingsTask extends DefaultTask {
 
@@ -41,7 +43,9 @@ public abstract class MigrateMappingsTask extends DefaultTask {
     @Optional
     @InputDirectory
     @PathSensitive(PathSensitivity.RELATIVE)
-    @Option(option = "mcpDir", description = "The directory containing the mappings to migrate to, using MCP's fields.csv and methods.csv format.")
+    @Option(
+            option = "mcpDir",
+            description = "The directory containing the mappings to migrate to, using MCP's fields.csv and methods.csv format.")
     public abstract DirectoryProperty getMcpDir();
 
     @InputDirectory
@@ -58,13 +62,14 @@ public abstract class MigrateMappingsTask extends DefaultTask {
         getInputDir().convention(getProject().getLayout().getProjectDirectory().dir("src/main/java"));
         getOutputDir().convention(getProject().getLayout().getProjectDirectory().dir("src/main/java"));
     }
-    
+
     @TaskAction
     public void migrateMappings() throws Exception {
-        if(!getMcpDir().isPresent()) {
+        if (!getMcpDir().isPresent()) {
             throw new IllegalArgumentException("A target mapping must be set using --mcpDir.");
         }
-        GenSrgMappingsTask genSrgMappings = getProject().getTasks().named("generateForgeSrgMappings", GenSrgMappingsTask.class).get();
+        GenSrgMappingsTask genSrgMappings = getProject().getTasks()
+                .named("generateForgeSrgMappings", GenSrgMappingsTask.class).get();
         File currentFields = genSrgMappings.getFieldsCsv().getAsFile().get();
         File currentMethods = genSrgMappings.getMethodsCsv().getAsFile().get();
 
@@ -73,11 +78,15 @@ public abstract class MigrateMappingsTask extends DefaultTask {
 
         MappingSet notchSrg = MappingFormats.SRG.read(srg.toPath());
         MappingSet currentSrgMcp = createSrgMcpMappingSet(notchSrg, readCsv(currentFields), readCsv(currentMethods));
-        MappingSet targetSrgMcp = createSrgMcpMappingSet(notchSrg, readCsv(new File(target, "fields.csv")), readCsv(new File(target, "methods.csv")));
+        MappingSet targetSrgMcp = createSrgMcpMappingSet(
+                notchSrg,
+                readCsv(new File(target, "fields.csv")),
+                readCsv(new File(target, "methods.csv")));
         MappingSet diffMcp = diff(currentSrgMcp, targetSrgMcp);
 
-        if(DEBUG_WRITE_DIFF) {
-            try (MappingsWriter w = MappingFormats.SRG.createWriter(new File(getProject().getRootDir(), "diff.srg").toPath())) {
+        if (DEBUG_WRITE_DIFF) {
+            try (MappingsWriter w = MappingFormats.SRG
+                    .createWriter(new File(getProject().getRootDir(), "diff.srg").toPath())) {
                 w.write(diffMcp);
             }
         }
@@ -85,23 +94,30 @@ public abstract class MigrateMappingsTask extends DefaultTask {
         final Mercury mercury = new Mercury();
 
         // There's probably a better way to do this
-        mercury.getClassPath().add(getProject().getTasks().named("packagePatchedMc", Jar.class).get().getArchiveFile().get().getAsFile().toPath());
-        mercury.getClassPath().add(getProject().getTasks().named("injectTags", InjectTagsTask.class).get().getOutputDir().getAsFile().get().toPath());
+        mercury.getClassPath().add(
+                getProject().getTasks().named("packagePatchedMc", Jar.class).get().getArchiveFile().get().getAsFile()
+                        .toPath());
+        mercury.getClassPath().add(
+                getProject().getTasks().named("injectTags", InjectTagsTask.class).get().getOutputDir().getAsFile().get()
+                        .toPath());
         for (File file : getProject().getConfigurations().getByName("compileClasspath").getFiles()) {
             mercury.getClassPath().add(file.toPath());
         }
-        // Fixes some issues like broken javadoc in Forge, and JDT not understanding Hodgepodge's obfuscated voxelmap targets.
+        // Fixes some issues like broken javadoc in Forge, and JDT not understanding Hodgepodge's obfuscated voxelmap
+        // targets.
         mercury.setGracefulClasspathChecks(true);
 
         mercury.getProcessors().add(MixinRemapper.create(diffMcp));
         mercury.getProcessors().add(MercuryRemapper.create(diffMcp));
 
-        mercury.setSourceCompatibility(getProject().getExtensions().getByType(JavaPluginExtension.class).getSourceCompatibility().toString());
+        mercury.setSourceCompatibility(
+                getProject().getExtensions().getByType(JavaPluginExtension.class).getSourceCompatibility().toString());
 
         mercury.rewrite(getInputDir().getAsFile().get().toPath(), getOutputDir().getAsFile().get().toPath());
     }
 
-    /** Returns the difference between two mappings of the same root.
+    /**
+     * Returns the difference between two mappings of the same root.
      *
      * @param mappingsA Mappings from O to A.
      * @param mappingsB Mappings from O to B.
@@ -112,26 +128,21 @@ public abstract class MigrateMappingsTask extends DefaultTask {
 
         forEachClassMapping(mappingsA, classA -> {
             ClassMapping<?, ?> classB = mappingsB.getClassMapping(classA.getFullObfuscatedName()).get();
-            ClassMapping<?, ?> classDiff = diff.getOrCreateClassMapping(
-                    classA.getFullDeobfuscatedName());
+            ClassMapping<?, ?> classDiff = diff.getOrCreateClassMapping(classA.getFullDeobfuscatedName());
 
-            for(FieldMapping fieldA : classA.getFieldMappings()) {
+            for (FieldMapping fieldA : classA.getFieldMappings()) {
                 FieldMapping fieldB = classB.getFieldMapping(fieldA.getObfuscatedName()).get();
 
-                classDiff.createFieldMapping(
-                                fieldA.getDeobfuscatedName())
-                        .setDeobfuscatedName(
-                                fieldB.getDeobfuscatedName());
+                classDiff.createFieldMapping(fieldA.getDeobfuscatedName())
+                        .setDeobfuscatedName(fieldB.getDeobfuscatedName());
             }
 
-            for(MethodMapping methodA : classA.getMethodMappings()) {
-                MethodMapping methodB = classB.getMethodMapping(methodA.getObfuscatedName(), methodA.getObfuscatedDescriptor()).get();
+            for (MethodMapping methodA : classA.getMethodMappings()) {
+                MethodMapping methodB = classB
+                        .getMethodMapping(methodA.getObfuscatedName(), methodA.getObfuscatedDescriptor()).get();
 
-                classDiff.createMethodMapping(
-                                methodA.getDeobfuscatedName(),
-                                methodA.getDeobfuscatedDescriptor())
-                        .setDeobfuscatedName(
-                                methodB.getDeobfuscatedName());
+                classDiff.createMethodMapping(methodA.getDeobfuscatedName(), methodA.getDeobfuscatedDescriptor())
+                        .setDeobfuscatedName(methodB.getDeobfuscatedName());
             }
         });
 
@@ -139,9 +150,9 @@ public abstract class MigrateMappingsTask extends DefaultTask {
     }
 
     private void forEachClassMapping(MappingSet mappings, Consumer<ClassMapping<?, ?>> callback) {
-        for(TopLevelClassMapping topLevelClass : mappings.getTopLevelClassMappings()) {
+        for (TopLevelClassMapping topLevelClass : mappings.getTopLevelClassMappings()) {
             callback.accept(topLevelClass);
-            for(InnerClassMapping inner : topLevelClass.getInnerClassMappings()) {
+            for (InnerClassMapping inner : topLevelClass.getInnerClassMappings()) {
                 forEachClassMappingInner(inner, callback);
             }
         }
@@ -149,33 +160,32 @@ public abstract class MigrateMappingsTask extends DefaultTask {
 
     private void forEachClassMappingInner(InnerClassMapping inner, Consumer<ClassMapping<?, ?>> callback) {
         callback.accept(inner);
-        for(InnerClassMapping innerer : inner.getInnerClassMappings()) {
+        for (InnerClassMapping innerer : inner.getInnerClassMappings()) {
             forEachClassMappingInner(innerer, callback);
         }
     }
 
-    private MappingSet createSrgMcpMappingSet(MappingSet notchSrg, Map<String, String> fields, Map<String, String> methods) {
+    private MappingSet createSrgMcpMappingSet(MappingSet notchSrg, Map<String, String> fields,
+            Map<String, String> methods) {
         MappingSet srgMcp = MappingSet.create();
 
         // In 1.7 everything is top level because proguard strips inner class info
-        for(TopLevelClassMapping notchSrgTopLevelClass : notchSrg.getTopLevelClassMappings()) {
-            ClassMapping<?, ?> srgMcpClass = srgMcp.getOrCreateClassMapping(notchSrgTopLevelClass.getFullDeobfuscatedName());
+        for (TopLevelClassMapping notchSrgTopLevelClass : notchSrg.getTopLevelClassMappings()) {
+            ClassMapping<?, ?> srgMcpClass = srgMcp
+                    .getOrCreateClassMapping(notchSrgTopLevelClass.getFullDeobfuscatedName());
 
-            for(FieldMapping notchSrgField : notchSrgTopLevelClass.getFieldMappings()) {
-                srgMcpClass.createFieldMapping(
-                                notchSrgField.getDeobfuscatedName())
-                        .setDeobfuscatedName(fields.getOrDefault(
-                                notchSrgField.getDeobfuscatedName(),
-                                notchSrgField.getDeobfuscatedName()));
+            for (FieldMapping notchSrgField : notchSrgTopLevelClass.getFieldMappings()) {
+                srgMcpClass.createFieldMapping(notchSrgField.getDeobfuscatedName()).setDeobfuscatedName(
+                        fields.getOrDefault(notchSrgField.getDeobfuscatedName(), notchSrgField.getDeobfuscatedName()));
             }
 
-            for(MethodMapping notchSrgMethod : notchSrgTopLevelClass.getMethodMappings()) {
+            for (MethodMapping notchSrgMethod : notchSrgTopLevelClass.getMethodMappings()) {
                 srgMcpClass.createMethodMapping(
-                                notchSrgMethod.getDeobfuscatedName(),
-                                notchSrgMethod.getDeobfuscatedDescriptor())
-                        .setDeobfuscatedName(methods.getOrDefault(
-                                notchSrgMethod.getDeobfuscatedName(),
-                                notchSrgMethod.getDeobfuscatedName()));
+                        notchSrgMethod.getDeobfuscatedName(),
+                        notchSrgMethod.getDeobfuscatedDescriptor()).setDeobfuscatedName(
+                                methods.getOrDefault(
+                                        notchSrgMethod.getDeobfuscatedName(),
+                                        notchSrgMethod.getDeobfuscatedName()));
             }
         }
 

--- a/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/modutils/MigrateMappingsTask.java
+++ b/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/modutils/MigrateMappingsTask.java
@@ -39,17 +39,17 @@ public class MigrateMappingsTask extends DefaultTask {
 
     @Option(option = "mcpDir", description = "The directory containing the mappings to migrate to, using MCP's fields.csv and methods.csv format.")
     public void setMcpDir(String mcpDir) {
-        this.mcpDir = new File(mcpDir);
+        this.mcpDir = new File(getProject().getProjectDir(), mcpDir);
     }
 
     @Option(option = "inputDir", description = "The directory containing the source code to migrate.")
     public void setInputDir(String inputDir) {
-        this.inputDir = new File(inputDir);
+        this.inputDir = new File(getProject().getProjectDir(), inputDir);
     }
 
     @Option(option = "outputDir", description = "The directory the migrated source code should be written to.")
     public void setOutputDir(String outputDir) {
-        this.outputDir = new File(outputDir);
+        this.outputDir = new File(getProject().getProjectDir(), outputDir);
     }
     
     @TaskAction

--- a/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/modutils/MigrateMappingsTask.java
+++ b/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/modutils/MigrateMappingsTask.java
@@ -1,0 +1,114 @@
+package com.gtnewhorizons.retrofuturagradle.modutils;
+
+import com.gtnewhorizons.retrofuturagradle.util.Utilities;
+import com.opencsv.CSVReader;
+import org.cadixdev.lorenz.MappingSet;
+import org.cadixdev.lorenz.io.MappingFormats;
+import org.cadixdev.lorenz.io.MappingsWriter;
+import org.cadixdev.lorenz.model.FieldMapping;
+import org.cadixdev.lorenz.model.MethodMapping;
+import org.cadixdev.lorenz.model.TopLevelClassMapping;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.tasks.TaskAction;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class MigrateMappingsTask extends DefaultTask {
+
+    @TaskAction
+    public void migrateMappings() throws IOException {
+        File current = new File(System.getProperty("user.home"), ".gradle/caches/minecraft/net/minecraftforge/forge/1.7.10-10.13.4.1614-1.7.10/unpacked/conf");
+        File target = new File(System.getProperty("user.home"), ".gradle/caches/minecraft/de/oceanlabs/mcp/mcp_stable/12");
+        File srg = new File(System.getProperty("user.home"), ".gradle/caches/minecraft/net/minecraftforge/forge/1.7.10-10.13.4.1614-1.7.10/unpacked/conf/packaged.srg");
+
+        MappingSet notchSrg = MappingFormats.SRG.read(srg.toPath());
+        MappingSet currentSrgMcp = createSrgMcpMappingSet(notchSrg, readCsv(new File(current, "fields.csv")), readCsv(new File(current, "methods.csv")));
+        MappingSet targetSrgMcp = createSrgMcpMappingSet(notchSrg, readCsv(new File(target, "fields.csv")), readCsv(new File(target, "methods.csv")));
+        MappingSet diffMcp = diff(currentSrgMcp, targetSrgMcp);
+        
+        try(MappingsWriter w = MappingFormats.SRG.createWriter(new File("diff.srg").toPath())) {
+            w.write(diffMcp);
+        }
+    }
+
+    /** Returns the difference between two mappings of the same root.
+     * 
+     * @param mappingsA Mappings from O to A.
+     * @param mappingsB Mappings from O to B.
+     * @return Mappings from A to B.
+     */
+    private MappingSet diff(MappingSet mappingsA, MappingSet mappingsB) {
+        MappingSet diff = MappingSet.create();
+        
+        for(TopLevelClassMapping topLevelClassA : mappingsA.getTopLevelClassMappings()) {
+            TopLevelClassMapping topLevelClassB = mappingsB.getTopLevelClassMapping(topLevelClassA.getFullObfuscatedName()).get();
+            TopLevelClassMapping topLevelClassDiff = diff.createTopLevelClassMapping(
+                    topLevelClassA.getFullDeobfuscatedName(),
+                    topLevelClassB.getFullDeobfuscatedName());
+            
+            for(FieldMapping fieldA : topLevelClassA.getFieldMappings()) {
+                FieldMapping fieldB = topLevelClassB.getFieldMapping(fieldA.getObfuscatedName()).get();
+                
+                topLevelClassDiff.createFieldMapping(
+                        fieldA.getDeobfuscatedName())
+                .setDeobfuscatedName(
+                        fieldB.getDeobfuscatedName());
+            }
+            
+            for(MethodMapping methodA : topLevelClassA.getMethodMappings()) {
+                MethodMapping methodB = topLevelClassB.getMethodMapping(methodA.getObfuscatedName(), methodA.getObfuscatedDescriptor()).get();
+                
+                topLevelClassDiff.createMethodMapping(
+                        methodA.getDeobfuscatedName(),
+                        methodA.getDeobfuscatedDescriptor())
+                .setDeobfuscatedName(
+                        methodB.getDeobfuscatedName());
+            }
+        }
+        
+        return diff;
+    }
+
+    private MappingSet createSrgMcpMappingSet(MappingSet notchSrg, Map<String, String> fields, Map<String, String> methods) {
+        MappingSet mcpSrg = MappingSet.create();
+
+        for(TopLevelClassMapping notchSrgTopLevelClass : notchSrg.getTopLevelClassMappings()) {
+            TopLevelClassMapping srgMcpTopLevelClass = mcpSrg.createTopLevelClassMapping(
+                    notchSrgTopLevelClass.getFullDeobfuscatedName(),
+                    notchSrgTopLevelClass.getFullDeobfuscatedName());
+            
+            for(FieldMapping notchSrgField : notchSrgTopLevelClass.getFieldMappings()) {
+                srgMcpTopLevelClass.createFieldMapping(
+                        notchSrgField.getDeobfuscatedName())
+                .setDeobfuscatedName(fields.getOrDefault(
+                        notchSrgField.getDeobfuscatedName(),
+                        notchSrgField.getDeobfuscatedName()));
+            }
+            
+            for(MethodMapping notchSrgMethod : notchSrgTopLevelClass.getMethodMappings()) {
+                srgMcpTopLevelClass.createMethodMapping(
+                        notchSrgMethod.getDeobfuscatedName(),
+                        notchSrgMethod.getDeobfuscatedDescriptor())
+                .setDeobfuscatedName(methods.getOrDefault(
+                        notchSrgMethod.getDeobfuscatedName(),
+                        notchSrgMethod.getDeobfuscatedName()));
+            }
+        }
+
+        return mcpSrg;
+    }
+
+    private static Map<String, String> readCsv(File csv) throws IOException {
+        Map<String, String> names = new HashMap<>(5000);
+        try (CSVReader csvReader = Utilities.createCsvReader(csv)) {
+            for (String[] line : csvReader) {
+                names.put(line[0], line[1]);
+            }
+        }
+        return names;
+    }
+
+}

--- a/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/modutils/MigrateMappingsTask.java
+++ b/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/modutils/MigrateMappingsTask.java
@@ -16,6 +16,7 @@ import org.cadixdev.mercury.Mercury;
 import org.cadixdev.mercury.mixin.MixinRemapper;
 import org.cadixdev.mercury.remapper.MercuryRemapper;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.jvm.tasks.Jar;
 import org.gradle.api.tasks.options.Option;
@@ -91,8 +92,7 @@ public class MigrateMappingsTask extends DefaultTask {
         mercury.getProcessors().add(MixinRemapper.create(diffMcp));
         mercury.getProcessors().add(MercuryRemapper.create(diffMcp));
 
-        // TODO actually get this from the project
-        mercury.setSourceCompatibility("17");
+        mercury.setSourceCompatibility(getProject().getExtensions().getByType(JavaPluginExtension.class).getSourceCompatibility().toString());
 
         mercury.rewrite(inputDir.toPath(), outputDir.toPath());
     }

--- a/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/modutils/ModUtils.java
+++ b/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/modutils/ModUtils.java
@@ -109,10 +109,10 @@ public class ModUtils {
             task.setGroup(TASK_GROUP_USER);
             task.setDescription(
                     "Migrate main source set to a new set of mappings");
-            task.dependsOn(project.getTasks().getByName("extractMcpData"));
-            task.dependsOn(project.getTasks().getByName("extractForgeUserdev"));
-            task.dependsOn(project.getTasks().getByName("packagePatchedMc"));
-            task.dependsOn(project.getTasks().getByName("injectTags"));
+            task.dependsOn("extractMcpData");
+            task.dependsOn("extractForgeUserdev");
+            task.dependsOn("packagePatchedMc");
+            task.dependsOn("injectTags");
         });
 
         if (!disableDependencyDeobfuscation) {

--- a/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/modutils/ModUtils.java
+++ b/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/modutils/ModUtils.java
@@ -109,6 +109,10 @@ public class ModUtils {
             task.setGroup(TASK_GROUP_USER);
             task.setDescription(
                     "Migrate main source set to a new set of mappings");
+            task.dependsOn(project.getTasks().getByName("taskExtractMcpData"));
+            task.dependsOn(project.getTasks().getByName("taskExtractForgeUserdev"));
+            task.dependsOn(project.getTasks().getByName("packagePatchedMc"));
+            task.dependsOn(project.getTasks().getByName("injectTags"));
         });
 
         if (!disableDependencyDeobfuscation) {

--- a/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/modutils/ModUtils.java
+++ b/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/modutils/ModUtils.java
@@ -119,7 +119,7 @@ public class ModUtils {
                     .set(mcpTasks.getTaskGenerateForgeSrgMappings().flatMap(GenSrgMappingsTask::getMethodsCsv));
             ConfigurableFileCollection cp = task.getCompileClasspath();
             cp.from(project.getConfigurations().getByName("compileClasspath"));
-            cp.from(project.files(project.getTasks().named("packagePatchedMc", Jar.class)));
+            cp.from(project.getTasks().named("packagePatchedMc", Jar.class));
             cp.from(
                     project.getExtensions().getByType(JavaPluginExtension.class).getSourceSets()
                             .getByName("injectedTags").getOutput());

--- a/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/modutils/ModUtils.java
+++ b/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/modutils/ModUtils.java
@@ -109,8 +109,8 @@ public class ModUtils {
             task.setGroup(TASK_GROUP_USER);
             task.setDescription(
                     "Migrate main source set to a new set of mappings");
-            task.dependsOn(project.getTasks().getByName("taskExtractMcpData"));
-            task.dependsOn(project.getTasks().getByName("taskExtractForgeUserdev"));
+            task.dependsOn(project.getTasks().getByName("extractMcpData"));
+            task.dependsOn(project.getTasks().getByName("extractForgeUserdev"));
             task.dependsOn(project.getTasks().getByName("packagePatchedMc"));
             task.dependsOn(project.getTasks().getByName("injectTags"));
         });

--- a/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/modutils/ModUtils.java
+++ b/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/modutils/ModUtils.java
@@ -107,8 +107,7 @@ public class ModUtils {
 
         project.getTasks().register("migrateMappings", MigrateMappingsTask.class, task -> {
             task.setGroup(TASK_GROUP_USER);
-            task.setDescription(
-                    "Migrate main source set to a new set of mappings");
+            task.setDescription("Migrate main source set to a new set of mappings");
             task.dependsOn("extractMcpData");
             task.dependsOn("extractForgeUserdev");
             task.dependsOn("packagePatchedMc");

--- a/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/modutils/ModUtils.java
+++ b/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/modutils/ModUtils.java
@@ -105,6 +105,12 @@ public class ModUtils {
                     "Apply MCP decompiler cleanup to the main source set, doing things like replacing numerical OpenGL constants with their names");
         });
 
+        project.getTasks().register("migrateMappings", MigrateMappingsTask.class, task -> {
+            task.setGroup(TASK_GROUP_USER);
+            task.setDescription(
+                    "Migrate main source set to a new set of mappings");
+        });
+
         if (!disableDependencyDeobfuscation) {
             project.getDependencies().getAttributesSchema().attribute(DEOBFUSCATOR_TRANSFORMED, ams -> {
                 ams.getCompatibilityRules().add(DeobfuscatorTransformerCompatRules.class);

--- a/testdepmod/build.gradle.kts
+++ b/testdepmod/build.gradle.kts
@@ -28,6 +28,20 @@ buildscript {
                 includeGroup("net.minecraft")
             }
         }
+        maven {
+            name = "paper"
+            url = uri("https://papermc.io/repo/repository/maven-snapshots/")
+            mavenContent {
+                includeGroup("org.cadixdev")
+            }
+        }
+        maven {
+            name = "sonatype"
+            url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+            mavenContent {
+                includeGroup("org.cadixdev")
+            }
+        }
         mavenCentral {}
     }
 }

--- a/testmod/build.gradle.kts
+++ b/testmod/build.gradle.kts
@@ -30,6 +30,20 @@ buildscript {
                 includeGroup("net.minecraft")
             }
         }
+        maven {
+            name = "paper"
+            url = uri("https://papermc.io/repo/repository/maven-snapshots/")
+            mavenContent {
+                includeGroup("org.cadixdev")
+            }
+        }
+        maven {
+            name = "sonatype"
+            url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+            mavenContent {
+                includeGroup("org.cadixdev")
+            }
+        }
         mavenCentral()
     }
 }

--- a/testmod1.12/build.gradle.kts
+++ b/testmod1.12/build.gradle.kts
@@ -5,6 +5,25 @@ plugins {
     id("maven-publish")
 }
 
+buildscript {
+    repositories {
+        maven {
+            name = "paper"
+            url = uri("https://papermc.io/repo/repository/maven-snapshots/")
+            mavenContent {
+                includeGroup("org.cadixdev")
+            }
+        }
+        maven {
+            name = "sonatype"
+            url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+            mavenContent {
+                includeGroup("org.cadixdev")
+            }
+        }
+    }
+}
+
 repositories {
     mavenCentral()
     mavenLocal()


### PR DESCRIPTION
This PR adds the beginnings of a `migrateMappings` task inspired by [Loom's one](https://fabricmc.net/wiki/tutorial:migratemappings). It can remap regular Java source code as well as mixin targets. Currently only paths to local CSV files are supported as target mappings.

> **Note:** The added dependencies seem to greatly slow down the shadow task ~~(2->7 minutes)~~ (actually it's "just" 2->3 minutes), so it might be wise to hold off on merging this until that gets addressed.
>
> Addressed in #59

## Testing

I tested it with Hodgepodge in the following way:

1. Run `./gradlew migrateMappings --mcpDir "~/.gradle/caches/minecraft/de/oceanlabs/mcp/mcp_stable/12"`
2. Add `minecraft.useForgeEmbeddedMappings = false` to the buildscript (causing the default of `stable_12` to be used) and reimport
3. Fix any issues that pop up
4. Run `runClient`

I got the game to run with only some minor adjustments.
<details>
<summary>Hodgepodge details</summary>

1. JDT gets confused by the mrtjpcore mixin targets, causing it to change `@Mixin(PlacementLib$.class)` to `@Mixin(.class)`. I simply reverted this, but it could also be worked around by changing them to string constants.
2. The `rayTraceBlocks` target in `MixinWorld_FixXray` is ambiguous with the new mappings, so it needed to be made explicit (`rayTraceBlocks(Lnet/minecraft/util/Vec3;Lnet/minecraft/util/Vec3;ZZZ)Lnet/minecraft/util/MovingObjectPosition;`).
3. I needed to disable NEI because its transformer caused an ASM error. This is going to be the hardest issue to properly fix, as it will require introducing a system to safely remap string constants in mods.
</details>
