### PR TITLE
Fix old shadow jar still getting published

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -354,7 +354,7 @@ tasks.named<Jar>("javadocJar").configure { from(fileTree("..").include("docs/*")
 publishing {
   publications {
     create<MavenPublication>("retrofuturagradle") {
-      shadow.component(this)
+      artifact(combinedShadowJar)
       artifact(tasks.named("sourcesJar"))
       artifact(tasks.named("javadocJar"))
     }


### PR DESCRIPTION
Follow-up to #59

I broke this in the very last commit 🤦 