### PR TITLE
Fix generateForgeSrgMappings always using default location in onlyIf

### DIFF
--- a/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/mcp/SharedMCPTasks.java
+++ b/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/mcp/SharedMCPTasks.java
@@ -201,11 +201,7 @@ public class SharedMCPTasks<McExtType extends IMinecraftyExtension> {
                 .register("generateForgeSrgMappings", GenSrgMappingsTask.class, task -> {
                     task.setGroup(TASK_GROUP_INTERNAL);
                     task.dependsOn(taskExtractMcpData, taskExtractForgeUserdev);
-                    final Provider<Directory> srgLocation = forgeSrgLocation; // configuration cache fix
-                    task.onlyIf(t -> {
-                        File root = srgLocation.get().getAsFile();
-                        return !(root.isDirectory() && new File(root, "notch-srg.srg").isFile());
-                    });
+                    task.onlyIf(t -> !task.getNotchToSrg().get().getAsFile().isFile());
                     // inputs
                     Provider<Integer> mcVer = mcExt.getMinorMcVersion();
                     task.getInputSrg().set(
@@ -228,7 +224,6 @@ public class SharedMCPTasks<McExtType extends IMinecraftyExtension> {
                     task.getMcpToNotch().set(srgFile("mcp-notch.srg"));
                     task.getSrgExc().set(srgFile("srg.exc"));
                     task.getMcpExc().set(srgFile("mcp.exc"));
-                    task.doFirst(new MkdirAction(forgeSrgLocation));
                 });
 
         // Set up dependencies across the cache-writing tasks to suppress Gradle errors about this.


### PR DESCRIPTION
This caused custom mappings to not get generated if mappings already existed in the default directory.

## Reproducing

1. Build a mod using official mappings (causing `~/.gradle/caches/minecraft/de/oceanlabs/mcp/mcp_stable/12/rfg_srgs` to get populated):
```gradle
minecraft {
    useForgeEmbeddedMappings = false
}
```

2. Build a mod using custom mappings:
```gradle
minecraft {
    useForgeEmbeddedMappings = false
}

tasks.generateForgeSrgMappings {
    methodsCsv = file("/path/to/methods.csv")
    fieldsCsv = file("/path/to/fields.csv")

    notchToSrg = layout.buildDirectory.file("userdev_local/notch-srg.srg")
    notchToMcp = layout.buildDirectory.file("userdev_local/notch-mcp.srg")
    srgToMcp = layout.buildDirectory.file("userdev_local/srg-mcp.srg")
    mcpToSrg = layout.buildDirectory.file("userdev_local/mcp-srg.srg")
    mcpToNotch = layout.buildDirectory.file("userdev_local/mcp-notch.srg")
    srgExc = layout.buildDirectory.file("userdev_local/srg.exc")
    mcpExc = layout.buildDirectory.file("userdev_local/mcp.exc")
}
```

Prior to this PR, an error would get generated saying `userdev_local/srg.exc` doesn't exist since the task doesn't run.