### PR TITLE
Add a deprecation notice for running Gradle under Java 8-20. Modding for Java 8 WILL still be supported, this is just about Gradle itself.

### DIFF
--- a/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/UserDevPlugin.java
+++ b/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/UserDevPlugin.java
@@ -3,6 +3,7 @@
  */
 package com.gtnewhorizons.retrofuturagradle;
 
+import org.gradle.api.JavaVersion;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.plugins.JavaLibraryPlugin;
@@ -23,6 +24,12 @@ public class UserDevPlugin implements Plugin<Project> {
 
         if (GradleVersion.current().compareTo(GradleVersion.version("7.6")) < 0) {
             throw new IllegalStateException("Using RetroFuturaGradle requires at least Gradle 7.6.");
+        }
+
+        if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_21)) {
+            project.getLogger().error(
+                    "[DEPRECATION NOTICE] Support for running Gradle using Java versions older than 21 with the RetroFuturaGradle plugin is scheduled to be removed, please upgrade your local and CI workflow Java version to 21 or newer. "
+                            + "This does NOT mean that mod code has to use newer Java, the Gradle process itself will require Java 21 but the compiler and mod code can keep on using Java 8.");
         }
 
         RfgCacheService.register(project.getGradle());


### PR DESCRIPTION
On plugin initialization, complain in the log if running under a Java version older than 21.
This is to prepare for an update to the minimum Java requirements for the plugin itself to allow using various modern Java libraries for source code manipulation. Gradle itself will probably require Java 17 or newer with the 9.0 release update when that happens.

Modding using the Java 8 toolchain for compiling, testing and running the game WILL still be supported, Gradle can use a different JVM for running itself and the code it compiles.