### PR TITLE
Fix use MinecraftTasks when not register yet.

### DIFF
--- a/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/minecraft/MinecraftTasks.java
+++ b/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/minecraft/MinecraftTasks.java
@@ -256,7 +256,7 @@ public final class MinecraftTasks {
         taskRunVanillaClient = project.getTasks()
                 .register("runVanillaClient", RunMinecraftTask.class, Distribution.CLIENT);
         taskRunVanillaClient.configure(task -> {
-            task.setup(project);
+            task.setup(project,this);
             task.setDescription("Runs the vanilla (unmodified) game client, use --debug-jvm for debugging");
             task.setGroup(TASK_GROUP_USER);
             task.dependsOn(taskDownloadVanillaJars, taskDownloadVanillaAssets);
@@ -272,7 +272,7 @@ public final class MinecraftTasks {
         taskRunVanillaServer = project.getTasks()
                 .register("runVanillaServer", RunMinecraftTask.class, Distribution.DEDICATED_SERVER);
         taskRunVanillaServer.configure(task -> {
-            task.setup(project);
+            task.setup(project,this);
             task.setDescription("Runs the vanilla (unmodified) game server, use --debug-jvm for debugging");
             task.setGroup(TASK_GROUP_USER);
             task.dependsOn(taskDownloadVanillaJars);

--- a/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/minecraft/RunMinecraftTask.java
+++ b/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/minecraft/RunMinecraftTask.java
@@ -105,9 +105,8 @@ public abstract class RunMinecraftTask extends JavaExec {
     /**
      * Run this in the first configuration block of the task, constructors can't register actions so this is necessary
      */
-    public void setup(Project project) {
+    public void setup(Project project, MinecraftTasks mcTasks) {
         MinecraftExtension mcExt = Objects.requireNonNull(project.getExtensions().getByType(MinecraftExtension.class));
-        MinecraftTasks mcTasks = Objects.requireNonNull(project.getExtensions().getByType(MinecraftTasks.class));
         getTweakClasses().convention(mcExt.getExtraTweakClasses());
         setWorkingDir(mcTasks.getRunDirectory());
         getLwjglVersion().convention(mcExt.getMainLwjglVersion());
@@ -144,6 +143,12 @@ public abstract class RunMinecraftTask extends JavaExec {
         }
 
         doFirst("setup late-binding arguments", this::setupLateArgs);
+    }
+
+
+    public void setup(Project project) {
+        MinecraftTasks mcTasks = Objects.requireNonNull(project.getExtensions().getByType(MinecraftTasks.class));
+        setup(project, mcTasks);
     }
 
     public List<String> calculateArgs() {


### PR DESCRIPTION
Today I'm trying to compile TwilightFlower/lwjgl3ify.
But always met "Extension of type 'MinecraftTasks' does not exist.".
So I found that it use MinecraftTasks before register it.
Maybe my code is ugly, but I think it need to be fixed.

Sorry for poor English.

![图片](https://github.com/user-attachments/assets/19a7d0a3-a572-4e5c-8d5c-ef0b25f99bd8)
