### PR TITLE
Fix paper maven

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -51,7 +51,7 @@ repositories {
   }
   maven {
     name = "paper"
-    url = uri("https://papermc.io/repo/repository/maven-snapshots/")
+    url = uri("https://repo.papermc.io/repository/maven-public/")
     mavenContent {
       includeGroup("org.cadixdev")
     }

--- a/testdepmod/build.gradle.kts
+++ b/testdepmod/build.gradle.kts
@@ -30,7 +30,7 @@ buildscript {
         }
         maven {
             name = "paper"
-            url = uri("https://papermc.io/repo/repository/maven-snapshots/")
+            url = uri("https://repo.papermc.io/repository/maven-public/")
             mavenContent {
                 includeGroup("org.cadixdev")
             }

--- a/testmod/build.gradle.kts
+++ b/testmod/build.gradle.kts
@@ -32,7 +32,7 @@ buildscript {
         }
         maven {
             name = "paper"
-            url = uri("https://papermc.io/repo/repository/maven-snapshots/")
+            url = uri("https://repo.papermc.io/repository/maven-public/")
             mavenContent {
                 includeGroup("org.cadixdev")
             }

--- a/testmod1.12/build.gradle.kts
+++ b/testmod1.12/build.gradle.kts
@@ -9,7 +9,7 @@ buildscript {
     repositories {
         maven {
             name = "paper"
-            url = uri("https://papermc.io/repo/repository/maven-snapshots/")
+            url = uri("https://repo.papermc.io/repository/maven-public/")
             mavenContent {
                 includeGroup("org.cadixdev")
             }


### PR DESCRIPTION
Paper change their maven url to `https://repo.papermc.io/repository/maven-public/` from `https://papermc.io/repo/repository/maven-snapshots/`

Simply update the maven url so the project could be build correctly