### PR TITLE
Fix mcp to notch generated mapping not having notch class names

### DIFF
--- a/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/mcp/GenSrgMappingsTask.java
+++ b/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/mcp/GenSrgMappingsTask.java
@@ -176,6 +176,8 @@ public abstract class GenSrgMappingsTask extends DefaultTask {
                 mcpToSrg.write(line);
                 mcpToSrg.newLine();
 
+                line = String.format("CL: %s %s", e.getValue(), e.getKey());
+
                 // output is notch
                 mcpToNotch.write(line);
                 mcpToNotch.newLine();


### PR DESCRIPTION
Missing line is present on the forgegradle 2.3 source.
Noticed while trying to use SpecialSource to obfuscate a mod jar.
Other generated mappings looks correct to me.