### PR TITLE
Added compile-time interface injection

### DIFF
--- a/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/mcp/InterfaceInjectionTask.java
+++ b/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/mcp/InterfaceInjectionTask.java
@@ -1,0 +1,137 @@
+package com.gtnewhorizons.retrofuturagradle.mcp;
+
+import static com.gtnewhorizons.retrofuturagradle.Constants.JST_TOOL_ARTIFACT;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.output.TeeOutputStream;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.Project;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.CacheableTask;
+import org.gradle.api.tasks.Classpath;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.jvm.toolchain.JavaLauncher;
+import org.gradle.process.ExecOperations;
+
+import com.google.common.collect.ImmutableSet;
+import com.gtnewhorizons.retrofuturagradle.util.HashUtils;
+import com.gtnewhorizons.retrofuturagradle.util.IJarTransformTask;
+import com.gtnewhorizons.retrofuturagradle.util.MessageDigestConsumer;
+
+@CacheableTask
+public abstract class InterfaceInjectionTask extends DefaultTask implements IJarTransformTask {
+
+    @InputFiles
+    @PathSensitive(PathSensitivity.NONE)
+    public abstract ConfigurableFileCollection getInterfaceInjectionConfigs();
+
+    @Override
+    public MessageDigestConsumer hashInputs() {
+        return HashUtils.addPropertyToHash(getInterfaceInjectionConfigs());
+    }
+
+    @InputFiles
+    @Classpath
+    public abstract ConfigurableFileCollection getCompileClasspath();
+
+    @Internal
+    public abstract Property<JavaLauncher> getJavaLauncher();
+
+    @Inject
+    protected abstract ExecOperations getExecOperations();
+
+    @TaskAction
+    public void injectInterfaces() throws IOException {
+
+        final Set<File> injectionConfigs = new ImmutableSet.Builder<File>().addAll(getInterfaceInjectionConfigs()).build();
+
+        if (injectionConfigs.isEmpty()) {
+            Files.copy(
+                    getInputJar().get().getAsFile().toPath(),
+                    getOutputJar().get().getAsFile().toPath(),
+                    StandardCopyOption.REPLACE_EXISTING);
+            return;
+        }
+
+        final Project project = getProject();
+        final Logger logger = getLogger();
+        final File toolExecutable = resolveTool(getProject(), JST_TOOL_ARTIFACT);
+        final List<String> programArgs = new ArrayList<>();
+
+        programArgs.add("--enable-interface-injection");
+
+        for (File config : injectionConfigs) {
+            programArgs.add("--interface-injection-data=" + config.getAbsolutePath());
+        }
+
+        logger.lifecycle("Applying interface injection configs: {}", injectionConfigs);
+
+        logger.info("Using JST: {}", toolExecutable);
+
+        final File inputJar = getInputJar().get().getAsFile();
+        final File outputJar = getOutputJar().get().getAsFile();
+
+        final String libraryPaths = getCompileClasspath()
+            .getFiles()
+            .stream()
+            .map(File::getAbsolutePath)
+            .collect(Collectors.joining(System.lineSeparator()));
+
+        final File librariesFile = project.getResources()
+            .getText()
+            .fromString(libraryPaths)
+            .asFile(StandardCharsets.UTF_8.name());
+
+        programArgs.add("--libraries-list=" + librariesFile.getAbsolutePath());
+
+        programArgs.add(inputJar.getAbsolutePath());
+        programArgs.add(outputJar.getAbsolutePath());
+
+        logger.info("Program Args: {}", programArgs);
+
+        getExecOperations().javaexec(exec -> {
+            exec.classpath(toolExecutable);
+            try {
+                final File logFile = FileUtils.getFile(
+                    project.getLayout().getBuildDirectory().get().getAsFile(),
+                    MCPTasks.RFG_DIR,
+                    "jst_log_" + getName() + ".log");
+                final OutputStream logFileStream = FileUtils.openOutputStream(logFile);
+                final OutputStream logStream = new TeeOutputStream(logFileStream, System.out);
+                exec.setStandardOutput(logStream);
+                exec.setErrorOutput(logStream);
+                logFileStream.write(String.format("%s %s%n", toolExecutable, programArgs).getBytes(StandardCharsets.UTF_8));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            exec.setMinHeapSize("512M");
+            exec.setMaxHeapSize("2G");
+            exec.setArgs(programArgs);
+            exec.setExecutable(getJavaLauncher().get().getExecutablePath().toString());
+        }).assertNormalExitValue();
+    }
+
+    public static File resolveTool(final Project project, final String tool) {
+        return project.getConfigurations().detachedConfiguration(project.getDependencies().create(tool)).getFiles()
+                .iterator().next();
+    }
+}

--- a/testmod/build.gradle.kts
+++ b/testmod/build.gradle.kts
@@ -54,6 +54,16 @@ plugins {
 }
 
 repositories {
+    maven {
+        // RetroFuturaGradle
+        name = "GTNH Maven"
+        url = uri("https://nexus.gtnewhorizons.com/repository/public/")
+        mavenContent {
+            includeGroup("com.gtnewhorizons")
+            includeGroupByRegex("com\\.gtnewhorizons\\..+")
+        }
+    }
+    gradlePluginPortal()
     mavenCentral()
     mavenLocal()
 }
@@ -78,6 +88,14 @@ minecraft {
 
 tasks.injectTags.configure {
     outputClassName.set("testmod.Tags")
+}
+
+tasks.injectInterfaces.configure {
+    // The path here can be anything, it doesn't need to be in injectedInterfaces
+    // The contents of these files must match this:
+    // https://github.com/neoforged/JavaSourceTransformer?tab=readme-ov-file#interface-injection
+    // Interfaces should only be added to injectedInterfaces, if they are added to main/mixin/test/etc then MC will not compile
+    interfaceInjectionConfigs.setFrom("src/injectedInterfaces/interfaces.json", "src/injectedInterfaces/interfaces2.json");
 }
 
 publishing {

--- a/testmod/src/injectedInterfaces/interfaces.json
+++ b/testmod/src/injectedInterfaces/interfaces.json
@@ -1,0 +1,3 @@
+{
+  "net/minecraft/world/World": ["testmod/InjectionTest"]
+}

--- a/testmod/src/injectedInterfaces/interfaces2.json
+++ b/testmod/src/injectedInterfaces/interfaces2.json
@@ -1,0 +1,3 @@
+{
+  "net/minecraft/client/multiplayer/WorldClient": ["testmod/InjectionTest"]
+}

--- a/testmod/src/injectedInterfaces/java/testmod/InjectionTest.java
+++ b/testmod/src/injectedInterfaces/java/testmod/InjectionTest.java
@@ -1,0 +1,8 @@
+package testmod;
+
+public interface InjectionTest {
+
+    default void doTheThing() {
+        
+    }
+}

--- a/testmod/src/main/java/testmod/TestMod.java
+++ b/testmod/src/main/java/testmod/TestMod.java
@@ -2,8 +2,15 @@ package testmod;
 
 import cpw.mods.fml.common.Mod;
 import cpw.mods.fml.common.event.*;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
 import net.minecraft.block.Block;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.WorldClient;
 import net.minecraft.init.Blocks;
+import net.minecraft.world.World;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -37,5 +44,21 @@ public class TestMod {
         LOG.info("TestMod postInit");
         Block bed = Blocks.bed;
         LOG.info("Bed name is {}", bed.getUnlocalizedName());
+    }
+
+    @SideOnly(Side.CLIENT)
+    private void interfaceCheck() {
+        // dummy code to make sure everything compiles properly
+
+        // the interface should be injected properly
+        World world = null;
+        world.doTheThing();
+        
+        WorldClient worldClient = null;
+        worldClient.doTheThing();
+
+        // the interface should be accessible to the main source set
+        InjectionTest test = null;
+        test.doTheThing();
     }
 }


### PR DESCRIPTION
This adds compile-time interface injection via JST. I copied most of the task logic from the AT task. I inserted it after the AT task in the task dependency graph.

I also added a new source set for the interfaces so that the MC source set can compile against them properly. This set depends on the API set, and the main+test sets depend on the interface set. I'm not sure where the mixin set is defined, but hopefully the transient dep will be pulled in because I know it depends on main.

There's an example in the test mod that should compile fine. It adds a new interface to World and WorldClient. There's some code that should cause a syntax error if the injection isn't done properly.