### PR TITLE
Gradle configuration cache compatibility improvements

### DIFF
--- a/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/mcp/DecompileTask.java
+++ b/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/mcp/DecompileTask.java
@@ -15,7 +15,6 @@ import javax.inject.Inject;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FileUtils;
 import org.gradle.api.DefaultTask;
-import org.gradle.api.Project;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFileProperty;
@@ -166,7 +165,8 @@ public abstract class DecompileTask extends DefaultTask implements IJarTransform
             exec.setWorkingDir(getFernflower().get().getAsFile().getParentFile());
             try {
                 exec.setStandardOutput(
-                        FileUtils.openOutputStream(getBuildDir().file(MCPTasks.RFG_DIR + "/fernflower_log.log").get().getAsFile()));
+                        FileUtils.openOutputStream(
+                                getBuildDir().file(MCPTasks.RFG_DIR + "/fernflower_log.log").get().getAsFile()));
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }

--- a/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/modutils/ModUtils.java
+++ b/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/modutils/ModUtils.java
@@ -185,11 +185,13 @@ public class ModUtils {
                 Provider<Directory> tempMixinDir = project.getLayout().getBuildDirectory().dir("tmp/mixins");
                 Provider<RegularFile> mixinSrg = tempMixinDir.map(it -> it.file("mixins.srg"));
                 Provider<RegularFile> mixinRefMapFile = tempMixinDir.map(it -> it.file(mixinRefMap.get()));
-                TaskProvider<ReobfuscatedJar> reobfJarTask = project.getTasks().named("reobfJar", ReobfuscatedJar.class);
+                TaskProvider<ReobfuscatedJar> reobfJarTask = project.getTasks()
+                        .named("reobfJar", ReobfuscatedJar.class);
                 reobfJarTask.configure(task -> task.getExtraSrgFiles().from(mixinSrg));
                 Provider<RegularFile> reobfSrg = reobfJarTask.flatMap(ReobfuscatedJar::getSrg);
-                //getLocationOnly is needed because JavaCompile compile options are read by intellij on project reload, and it causes an error because the srg task hasn't run yet
-                //Adding the file above to the task inputs fixes the task dependency chain breakage caused by this.
+                // getLocationOnly is needed because JavaCompile compile options are read by intellij on project reload,
+                // and it causes an error because the srg task hasn't run yet
+                // Adding the file above to the task inputs fixes the task dependency chain breakage caused by this.
                 Provider<RegularFile> reobfSrgLocation = reobfJarTask.flatMap(task -> task.getSrg().getLocationOnly());
                 SrgCommandLineArgs srgArgs = project.getObjects().newInstance(SrgCommandLineArgs.class);
                 srgArgs.getReobfSrgFile().set(reobfSrgLocation);
@@ -358,18 +360,23 @@ public class ModUtils {
     }
 
     public abstract static class SrgCommandLineArgs implements CommandLineArgumentProvider {
+
         @InputFile
         @PathSensitive(PathSensitivity.RELATIVE)
         public abstract RegularFileProperty getReobfSrgFile();
+
         @OutputFile
         public abstract RegularFileProperty getOutSrgFile();
+
         @OutputFile
         public abstract RegularFileProperty getOutRefMapFile();
+
         @Override
         public Iterable<String> asArguments() {
-            return Arrays.asList("-AreobfSrgFile=" + getReobfSrgFile().get().getAsFile(),
-                                 "-AoutSrgFile=" + getOutSrgFile().get().getAsFile(),
-                                 "-AoutRefMapFile=" + getOutRefMapFile().get().getAsFile());
+            return Arrays.asList(
+                    "-AreobfSrgFile=" + getReobfSrgFile().get().getAsFile(),
+                    "-AoutSrgFile=" + getOutSrgFile().get().getAsFile(),
+                    "-AoutRefMapFile=" + getOutRefMapFile().get().getAsFile());
         }
     }
 }


### PR DESCRIPTION
DecompileTask.java:

- Replaced the direct getProject() reference with internal properties for the build directory and the minecraft project extension object. This seems to be good enough for the config cache to work, and I haven't noticed any issues after this change.

ModUtils.java:

- Reimplemented the srg file weaving via caching-friendly property containers