### PR TITLE
configuration cache compat for gradle offline mode

### DIFF
--- a/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/mcp/SharedMCPTasks.java
+++ b/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/mcp/SharedMCPTasks.java
@@ -70,6 +70,11 @@ public class SharedMCPTasks<McExtType extends IMinecraftyExtension> {
         final File fernflower1DownloadLocation = Utilities.getCacheDir(project, "mcp", "fernflower-fixed.zip");
         fernflowerLocation = fernflower1Location;
         taskDownloadFernflower = project.getTasks().register("downloadFernflower", Download.class, task -> {
+            if (project.getGradle().getStartParameter().isOffline()) {
+                task.quiet(true); // Configuration cache compat
+                                  // (Download.class runs getProject() when gradle is in offline mode without the quiet
+                                  // flag)
+            }
             task.setGroup(TASK_GROUP_INTERNAL);
             task.src(Constants.URL_FERNFLOWER_1);
             final Provider<Integer> minorMcVersion = mcExt.getMinorMcVersion();

--- a/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/minecraft/MinecraftTasks.java
+++ b/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/minecraft/MinecraftTasks.java
@@ -134,6 +134,11 @@ public final class MinecraftTasks {
                         .map(mcVer -> Utilities.getCacheDir(project, "assets", "indexes", mcVer + ".json")));
         final ProviderFactory providers = mcExt.getProviderFactory();
         taskDownloadAssetManifest = project.getTasks().register("downloadAssetManifest", Download.class, task -> {
+            if (project.getGradle().getStartParameter().isOffline()) {
+                task.quiet(true); // Configuration cache compat
+                                  // (Download.class runs getProject() when gradle is in offline mode without the quiet
+                                  // flag)
+            }
             task.setGroup(TASK_GROUP_INTERNAL);
             final Property<String> mcVersion = mcExt.getMcVersion();
             task.src(
@@ -173,6 +178,11 @@ public final class MinecraftTasks {
                 mcExt.getMcVersion()
                         .map(mcVer -> Utilities.getCacheDir(project, MC_DOWNLOAD_PATH, mcVer, "server.jar")));
         taskDownloadVanillaJars = project.getTasks().register("downloadVanillaJars", Download.class, task -> {
+            if (project.getGradle().getStartParameter().isOffline()) {
+                task.quiet(true); // Configuration cache compat
+                                  // (Download.class runs getProject() when gradle is in offline mode without the quiet
+                                  // flag)
+            }
             task.setGroup(TASK_GROUP_INTERNAL);
             final Provider<RegularFile> vanillaClient = vanillaClientLocation;
             final Provider<RegularFile> vanillaServer = vanillaServerLocation;


### PR DESCRIPTION
The tasks `downloadFernflower`, `downloadAssetManifest`, and `downloadVanillaJars` break with the configuration cache when running gradle in offline mode (when these have already downloaded the required files).

This happens because `Download.class` from the gradle download plugin runs the following code for each file when in offline mode:
```
                    if (f.exists()) {
                        if (!isQuiet()) {
                            getProject().getLogger().info("Skipping existing file '" +
                                    f.getName() + "' in offline mode.");
                        }
                    } else {
                        throw new IllegalStateException("Unable to download file '" +
                                f.getName() + "' in offline mode.");
                    }
```
That `getProject()` in the task execution stage causes the problem. This PR fixes it by forcing quiet mode on these tasks in offline mode.