### PR TITLE
Expose the side of a RunMinecraftTask

### DIFF
--- a/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/minecraft/RunMinecraftTask.java
+++ b/plugin/src/main/java/com/gtnewhorizons/retrofuturagradle/minecraft/RunMinecraftTask.java
@@ -83,6 +83,7 @@ public abstract class RunMinecraftTask extends JavaExec {
     @Input
     public abstract ListProperty<String> getMcExtExtraRunJvmArguments();
 
+    @Internal
     private final Distribution side;
 
     @Inject
@@ -144,6 +145,10 @@ public abstract class RunMinecraftTask extends JavaExec {
         }
 
         doFirst("setup late-binding arguments", this::setupLateArgs);
+    }
+
+    public Distribution getSide() {
+        return this.side;
     }
 
     public List<String> calculateArgs() {


### PR DESCRIPTION
Expose the side of a runMinecraftTask. Can be used to set task working dir based on the side in downstream gradle plugins for example.